### PR TITLE
SSL_REDIRECT support and fix for ssl multihost

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -67,8 +67,8 @@ upstream {{ $host }} {
 }
 
 server {
-	{{ range $container := $containers }}
-		{{ if $container.Env.SSL_FILENAME }}
+	{{ range $index, $container := $containers }}
+		{{ if and ($container.Env.SSL_FILENAME) ( eq $index 0 ) }}
 			listen 443 ssl;
 			ssl_certificate /etc/nginx/ssl/{{ $container.Env.SSL_FILENAME }}.crt;
 			ssl_certificate_key /etc/nginx/ssl/{{ $container.Env.SSL_FILENAME }}.key;
@@ -107,13 +107,13 @@ server {
 	{{ end }}
 }
 
-{{ range $container := $containers }}
-	{{ if $container.Env.SSL_REDIRECT }}
+{{ range $index, $container := $containers }}
+	{{ if and ($container.Env.SSL_REDIRECT) (eq $index 0) }}
 	server {
 		server_name {{ $host }};
-        	return         301 https://$server_name$request_uri;
+		return         301 https://$server_name$request_uri;
 	}
-        {{ end }}
+	{{ end }}
 {{ end }}
 
 {{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -106,4 +106,14 @@ server {
 		{{ end }}
 	{{ end }}
 }
+
+{{ range $container := $containers }}
+	{{ if $container.Env.SSL_REDIRECT }}
+	server {
+		server_name {{ $host }};
+        	return         301 https://$server_name$request_uri;
+	}
+        {{ end }}
+{{ end }}
+
 {{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -77,11 +77,18 @@ server {
 	server_name {{ $host }};
 
 	location / {
-		{{ range $container := $containers }}
-			{{ if $container.Env.HTPASSWD_FILENAME }}
+		{{ range $index, $container := $containers }}
+			{{ if and ( $container.Env.HTPASSWD_FILENAME ) ( eq $index 0 ) }}
 				auth_basic "Restricted";
 				auth_basic_user_file /etc/nginx/htpasswd/{{ $container.Env.HTPASSWD_FILENAME }}.htpasswd;
 			{{ end }}
+
+ 			{{ if and ($container.Env.ROOT_REDIRECT ) ( eq $index 0 ) }}
+                        if ( $request_uri = "/" ) {
+                                return 301 http://$server_name/{{ $container.Env.ROOT_REDIRECT }};
+                        }
+                        {{ end }}
+
 		{{ end }}
 
 		proxy_pass http://{{ $host }};


### PR DESCRIPTION
Added support for SSL_REDIRECT env parameter which add a redirect from http to https.

There is also a fix for a problem with multiple instances with the same hostname using ssl.
If you run two or more containers with same value for VIRTUAL_HOST and SSL_FILENAME enabled, for example:

> docker run -e VIRTUAL_HOST=test.foo.com -e SSL_FILENAME=test.foo.com myimages
> docker run -e VIRTUAL_HOST=test.foo.com -e SSL_FILENAME=test.foo.com myimages
> an invalid nginx file is created because the ssl directives (list 443 and ssl_certificate... ) are duplicated.

A workaround could be to run (I didn't test it)  the containers with different parameters like these:

> docker run -e VIRTUAL_HOST=test.foo.com -e SSL_FILENAME=test.foo.com myimages
> docker run -e VIRTUAL_HOST=test.foo.com myimages
> docker run -e VIRTUAL_HOST=test.foo.com myimages

But this is not good in particular if you use utilities like fig/docker-compose to startup your containers.

Probably my fix is not the best solution to solve the problem (this is the first time I play with GO template and to be honest I don't like it very much), but it works for me.

Ciao,
Lorenzo
